### PR TITLE
Master fix log in npu plugin

### DIFF
--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -749,6 +749,16 @@ ov::SupportedOpsMap Plugin::query_model(const std::shared_ptr<const ov::Model>& 
 }
 
 ov::SoPtr<ICompiler> Plugin::getCompiler(const Config& config) const {
+    //compiled_model, import_model and query model all need call this `getCompiler`
+
+    //need update log and pass the 'properties' in input arguments to global config, then in `getCompiler()` will show log.
+    //Q&A, why trace log can show log in `getCompiler()`?
+    //todo: maybe to use a functin to warp the two line.
+
+    _globalConfig.update(localConfig);
+    if (_backends != nullptr) {
+        _backends->setup(_globalConfig);
+    }
     auto compilerType = config.get<COMPILER_TYPE>();
     return createCompiler(compilerType, _logger);
 }

--- a/src/plugins/intel_npu/src/utils/src/logger/logger.cpp
+++ b/src/plugins/intel_npu/src/utils/src/logger/logger.cpp
@@ -64,7 +64,7 @@ Logger& Logger::global() {
     }
     static Logger log("global", logLvl);
 #else
-    static Logger log("global", ov::log::Level::NO);
+    static Logger log("global", ov::log::Level::ERROR);
 #endif
     return log;
 }
@@ -78,7 +78,8 @@ Logger Logger::clone(std::string_view name) const {
 
 bool Logger::isActive(ov::log::Level msgLevel) const {
     return static_cast<int32_t>(msgLevel) <= static_cast<int32_t>(_logLevel);
-}
+}// info (2) <= defualt?
+//default is trace:  2<=4
 
 std::ostream& Logger::getBaseStream() {
     return std::cout;


### PR DESCRIPTION
### Details:
 - OV plugin part:
   - global config set by `OV_NPU_LOG_LEVEL`, will impact the log behavior in plugin constructor and backend constructor
   - config is updated in `compile_model()`, `import_model()`, `query_model()`. update code( merge config: [compile_model()](https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_npu/src/plugin/src/plugin.cpp#L585), [import_model()](https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_npu/src/plugin/src/plugin.cpp#L769), [query_model()](https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_npu/src/plugin/src/plugin.cpp#L747), [update config](https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_npu/src/plugin/src/plugin.cpp#L152))
   - log hpp, cpp
   
 - plugin cid part:
   - need update
 - plugin compiler part:
   - use passed config(from npu plugin) in [compile()](https://github.com/intel-innersource/applications.ai.vpu-accelerators.vpux-plugin/blob/develop/src/vpux_compiler/src/compiler.cpp#L714), [query()](https://github.com/intel-innersource/applications.ai.vpu-accelerators.vpux-plugin/blob/develop/src/vpux_compiler/src/compiler.cpp#L315), 
      - vpux compile workflow:  compile -> compileModel -> importNetwork + compileNetork, compile -> exportNetowrk
      - log [cpp](https://github.com/intel-innersource/applications.ai.vpu-accelerators.vpux-plugin/blob/develop/src/vpux_utils/src/core/logger.cpp), log [hpp](https://github.com/intel-innersource/applications.ai.vpu-accelerators.vpux-plugin/blob/develop/src/vpux_utils/include/vpux/utils/core/logger.hpp)
        ```
        vpux::Logger::Logger(StringLiteral name, LogLevel lvl): _name(name), _logLevel(lvl) {
        #if defined(VPUX_DEVELOPER_BUILD) || !defined(NDEBUG)
            if (const auto env = std::getenv("IE_NPU_LOG_FILTER")) {
                _logFilterStr = std::string(env);
            }
        #endif
        }
        ```
      - note: in vpux compiler part. most Logger::global() is used in op definition, conversion and transforms, such as `src/vpux_compiler/src/dialect/VPU/IR/ops/nce_max_pool.cpp`, `src/vpux_compiler/src/conversion/passes/VPU2VPUIP/bufferize_vpu_ops_interface.cpp` and `src/vpux_compiler/src/dialect/VPU/transforms/passes/manual_strategy_utils.cpp`. in include file, there default set log as `Logger::golbal()`, so need pass a need log variable when use the func.
      - src/vpux_compiler/tblgen/vpux/compiler/dialect/VPU/ops.td:131 VPU_NCE use ` static mlir::LogicalResult verifyKernel(IE::ConvolutionOp origOp, Logger log = Logger::global());` Corresponding code: src/vpux_compiler/src/dialect/VPU/IR/ops/nce_convolution.cpp
      - pass in dialect/**/transforms need initialize `Base::initLogger`   need to check whether update log level
      - 'src/vpux_utils' folder such as: `TaskList TaskList::selectTasksFromCluster(unsigned clusterId) const {
    auto log = Logger::global();`


I think it better to use file name to show which use which log
  - *Expected performance*
     - plugin constructor just perform global log


 - *...*

### Tickets:
 - *ticket-id*
