### PR TITLE
fix

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/shared_ops_optimization.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/shared_ops_optimization.cpp
@@ -80,9 +80,9 @@ bool inputs_from_same_source_or_equal_constants(const std::shared_ptr<Node>& lhs
 
 void collect_node_attrs(const std::shared_ptr<Node>& node,
                         std::unordered_map<std::shared_ptr<ov::Node>, ov::AnyMap>& node_attributes_cache) {
-    if (!node_attributes_cache.count(node))
+    if (node_attributes_cache.count(node))
         return;
-    static auto visitor = NodeComparingVisitor();
+    auto visitor = NodeComparingVisitor();
     node_attributes_cache[node] = visitor.visit_attributes(node);
 }
 

--- a/src/common/transformations/src/transformations/common_optimizations/shared_ops_optimization.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/shared_ops_optimization.cpp
@@ -80,7 +80,7 @@ bool inputs_from_same_source_or_equal_constants(const std::shared_ptr<Node>& lhs
 
 void collect_node_attrs(const std::shared_ptr<Node>& node,
                         std::unordered_map<std::shared_ptr<ov::Node>, ov::AnyMap>& node_attributes_cache) {
-    if (node_attributes_cache.count(node))
+    if (!node_attributes_cache.count(node))
         return;
     static auto visitor = NodeComparingVisitor();
     node_attributes_cache[node] = visitor.visit_attributes(node);

--- a/src/core/include/openvino/pass/manager.hpp
+++ b/src/core/include/openvino/pass/manager.hpp
@@ -45,8 +45,8 @@ public:
     std::shared_ptr<T> register_pass(Args&&... args) {
         auto rc = push_pass<T>(std::forward<Args>(args)...);
         rc->set_pass_config(m_pass_config);
-        if (m_per_pass_validation) {
-            push_pass<Validate>();
+        if (m_per_pass_validation) {// default value is true
+            push_pass<Validate>(); //add Validate after each pass
         }
         if (!Enable && !m_pass_config->is_enabled<T>()) {
             m_pass_config->disable<T>();

--- a/src/core/src/pass/manager.cpp
+++ b/src/core/src/pass/manager.cpp
@@ -338,7 +338,8 @@ bool ov::pass::Manager::run_passes(const std::shared_ptr<ov::Model>& model) {
     profiler.start_timer(m_name);
     for (const auto& pass : m_pass_list) {
         const auto& pass_name = pass->get_name();
-
+        // std::vector<std::shared_ptr<PassBase>> m_pass_list;
+        // pass is std::make_shared<T>, T is different derived pass
         profiler.start_timer(pass_name);
         pass_changed_model = run_pass(pass, model, pass_changed_model);
         profiler.stop_timer(pass_name, pass_changed_model);
@@ -355,7 +356,7 @@ bool ov::pass::Manager::run_passes(const std::shared_ptr<ov::Model>& model) {
 
 bool ov::pass::Manager::run_pass(const std::shared_ptr<PassBase>& pass,
                                  const std::shared_ptr<Model>& model,
-                                 bool needs_validate) {
+                                 bool needs_validate) {// sharedOpOptimization pass is false
     if (m_pass_config->is_disabled(pass->get_type_info())) {
         OPENVINO_DEBUG("Pass ", pass->get_name(), " is disabled.");
         return false;

--- a/src/core/src/preprocess/pre_post_process.cpp
+++ b/src/core/src/preprocess/pre_post_process.cpp
@@ -78,7 +78,7 @@ void transformation_pipeline(std::shared_ptr<ov::Model>& model) {
     manager.set_per_pass_validation(false);
 
     // prerequisite: the model structure optimization before applying of the markup
-    REGISTER_PASS(manager, SharedOpOptimization)
+    REGISTER_PASS(manager, SharedOpOptimization)////
 
     // 1. Set "disable_const_folding" attribute
     // we have to add a call into the PrePostProcessing, it runs before compile_model call
@@ -95,8 +95,9 @@ void transformation_pipeline(std::shared_ptr<ov::Model>& model) {
 
     // 2. Fusion transformations:
     REGISTER_PASS(manager, ConvertDivideWithConstant)
-    auto fusions = manager.register_pass<GraphRewrite>();
+    auto fusions = manager.register_pass<GraphRewrite>(); // return pass ptr, and use it ptr to do the following fusions operation
     // Gelu fusion have to be executed before MulConv fusion because Mul(X, 0.5) might be fused to Conv weights
+    // call manager.add_matcher()
     ADD_MATCHER(fusions, GeluFusion)
     ADD_MATCHER(fusions, MultiplyConvolutionFusion)
     ADD_MATCHER(fusions, MultiplyGroupConvolutionFusion)
@@ -272,7 +273,7 @@ void PrePostProcessor::dump(std::ostream& str) const {
 std::shared_ptr<Model> PrePostProcessor::build() {
     auto function = m_impl->m_function;
     std::tuple<std::unordered_set<std::string>, bool> existing_names{std::unordered_set<std::string>{}, false};
-    FunctionGuard guard(function);
+    FunctionGuard guard(function); // origin model backup
     bool need_validate = false;
     auto results = function->get_results();
     auto parameters_list = std::list<std::shared_ptr<op::v0::Parameter>>(function->get_parameters().begin(),


### PR DESCRIPTION
### Details:
CID test:
https://jenkins-npu-compiler.ir.intel.com/job/pub/job/IE-Packages/job/Release/job/tests/job/test_CiD-Windows/7589/ fix package
run again: https://jenkins-npu-compiler.ir.intel.com/job/pub/job/IE-Packages/job/Release/job/tests/job/test_CiD-Windows/7590/ pass

https://jenkins-npu-compiler.ir.intel.com/job/pub/job/IE-Packages/job/Release/job/tests/job/test_CiD-Windows/7591/ pass

etest log trace with issue:
get issue from prepostprocess.build()
for ticket: https://jira.devtools.intel.com/browse/EISW-180370
https://github.com/openvinotoolkit/openvino/blob/master/src/core/src/preprocess/pre_post_process.cpp#L319
https://github.com/openvinotoolkit/openvino/blob/master/src/core/src/preprocess/pre_post_process.cpp#L81
```
etests.exe --gtest_filter=sanity/ov_multi_compile.run/Intel_DNS_onnx_model_dense_FP32_Intel_DNS_ipFP16_opFP16_priorityMEDIUM_iter4_threads4_delay16384
					<?xml version="1.0" encoding="UTF-8" standalone="no"?>
					<avrf:logfile xmlns:avrf="Application Verifier">
					    <avrf:logSession TimeStarted="2025-09-03 : 17:50:46" PID="6584" Version="2">
					        <avrf:logEntry Time="2025-09-03 : 17:50:56" LayerName="Heaps" StopCode="0x13" Severity="Error">
					            <avrf:message>First chance access violation for current stack trace.</avrf:message>
					            <avrf:parameter1>231d42e0fa0 - Invalid address causing the exception.</avrf:parameter1>
					            <avrf:parameter2>7ffbe4ea35b3 - Code address executing the invalid access.</avrf:parameter2>
					            <avrf:parameter3>a310bfe2b0 - Exception record.</avrf:parameter3>
					            <avrf:parameter4>a310bfddc0 - Context record.</avrf:parameter4>
					            <avrf:stackTrace>
					                <avrf:trace>vrfcore!VerifierUnregisterLayer+57d ( @ 0)</avrf:trace>
					                <avrf:trace>verifier!VerifierStopMessage+bc ( @ 0)</avrf:trace>
					                <avrf:trace>ntdll!RtlApplicationVerifierStop+95 ( @ 0)</avrf:trace>
					                <avrf:trace>vfbasics!+7ffc2e912a1f ( @ 0)</avrf:trace>
					                <avrf:trace>vfbasics!+7ffc2e913cd4 ( @ 0)</avrf:trace>
					                <avrf:trace>vfbasics!+7ffc2e9148aa ( @ 0)</avrf:trace>
					                <avrf:trace>ntdll!RtlWow64GetCurrentCpuArea+486 ( @ 0)</avrf:trace>
					                <avrf:trace>ntdll!RtlWow64GetCurrentCpuArea+9e6 ( @ 0)</avrf:trace>
					                <avrf:trace>ntdll!KiUserExceptionDispatcher+2e ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::Node::get_default_output_index+623 ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::op::v1::StridedSlice::set_shrink_axis_mask+2cbf ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::pass::SequenceFusion::SequenceFusion+70fd ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::op::v3::NonZero::visit_attributes+ae ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::pass::SequenceFusion::SequenceFusion+6245 ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::pass::SequenceFusion::SequenceFusion+6647 ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::pass::SharedOpOptimization::run_on_model+d09 ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::pass::SharedOpOptimization::run_on_model+20 ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::pass::Manager::run_pass+2e8 ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::pass::Manager::run_passes+259 ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::preprocess::InputTensorInfo::set_spatial_static_shape+86b ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::preprocess::PrePostProcessor::build+531 ( @ 0)</avrf:trace>
					                <avrf:trace>etests!eTests::openvino::inference_graph_wrapper&lt;ovTestFixture&gt;::inference_graph_wrapper&lt;ovTestFixture&gt;+3b0 (D:\qb\workspace\33077\source\npu-driver\tests\etests\include\openvino\ov_inference_graph_wrapper.h @ 132)</avrf:trace>
					                <avrf:trace>etests!eTests::common::inference::inference&lt;ovTestFixture&gt;::inference&lt;ovTestFixture&gt;+85 (D:\qb\workspace\33077\source\npu-driver\tests\etests\include\common\inference\inference.h @ 79)</avrf:trace>
					                <avrf:trace>etests!eTests::common::inference::compile_test&lt;ovTestFixture&gt;::Run+ce (D:\qb\workspace\33077\source\npu-driver\tests\etests\include\common\compile.h @ 184)</avrf:trace>
					                <avrf:trace>etests!eTests::Runner::Execute&lt;eTests::common::inference::compile_test&lt;ovTestFixture&gt; &gt;+e (D:\qb\workspace\33077\source\npu-driver\tests\etests\include\common\runner.h @ 42)</avrf:trace>
					                <avrf:trace>etests!std::_Func_impl_no_alloc&lt;`ov_multi_compile_run_Test::TestBody&apos;::`2&apos;::&lt;lambda_1&gt;,void&gt;::_Do_call+a9 (D:\qb\workspace\33077\source\third_party\build-tools\ewdk\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.41.34120\include\functional @ 874)</avrf:trace>
					                <avrf:trace>etests!std::_Packaged_state&lt;void __cdecl(void)&gt;::_Call_immediate+1f (D:\qb\workspace\33077\source\third_party\build-tools\ewdk\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.41.34120\include\future @ 584)</avrf:trace>
					                <avrf:trace>etests!std::thread::_Invoke&lt;std::tuple&lt;std::packaged_task&lt;void __cdecl(void)&gt; &gt;,0&gt;+2e (D:\qb\workspace\33077\source\third_party\build-tools\ewdk\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.41.34120\include\thread @ 60)</avrf:trace>
					                <avrf:trace>etests!thread_start&lt;unsigned int (__cdecl*)(void *),1&gt;+4f (minkernel\crts\ucrt\src\appcrt\startup\thread.cpp @ 97)</avrf:trace>
					                <avrf:trace>vfbasics!+7ffc2e927943 ( @ 0)</avrf:trace>
					                <avrf:trace>KERNEL32!BaseThreadInitThunk+17 ( @ 0)</avrf:trace>
					                <avrf:trace>ntdll!RtlUserThreadStart+2c ( @ 0)</avrf:trace>
					            </avrf:stackTrace>
					        </avrf:logEntry>
					    </avrf:logSession>
					</avrf:logfile>

```

```
					.\etests.exe --gtest_filter=sanity/ov_multi_compile.run/Intel_DNS_onnx_model_dense_FP32_Intel_DNS_ipFP16_opFP16_priorityMEDIUM_iter30_threads8_delay9000
					
					<?xml version="1.0" encoding="UTF-8" standalone="no"?>
					<avrf:logfile xmlns:avrf="Application Verifier">
					    <avrf:logSession TimeStarted="2025-09-03 : 18:15:36" PID="5100" Version="2">
					        <avrf:logEntry Time="2025-09-03 : 18:15:46" LayerName="Heaps" StopCode="0x13" Severity="Error">
					            <avrf:message>First chance access violation for current stack trace.</avrf:message>
					            <avrf:parameter1>251af574fe1 - Invalid address causing the exception.</avrf:parameter1>
					            <avrf:parameter2>7ffbe57cbeaf - Code address executing the invalid access.</avrf:parameter2>
					            <avrf:parameter3>abdbcfda70 - Exception record.</avrf:parameter3>
					            <avrf:parameter4>abdbcfd580 - Context record.</avrf:parameter4>
					            <avrf:stackTrace>
					                <avrf:trace>vrfcore!VerifierUnregisterLayer+57d ( @ 0)</avrf:trace>
					                <avrf:trace>verifier!VerifierStopMessage+bc ( @ 0)</avrf:trace>
					                <avrf:trace>ntdll!RtlApplicationVerifierStop+95 ( @ 0)</avrf:trace>
					                <avrf:trace>vfbasics!+7ffc4bec2a1f ( @ 0)</avrf:trace>
					                <avrf:trace>vfbasics!+7ffc4bec3cd4 ( @ 0)</avrf:trace>
					                <avrf:trace>vfbasics!+7ffc4bec48aa ( @ 0)</avrf:trace>
					                <avrf:trace>ntdll!RtlWow64GetCurrentCpuArea+486 ( @ 0)</avrf:trace>
					                <avrf:trace>ntdll!RtlWow64GetCurrentCpuArea+9e6 ( @ 0)</avrf:trace>
					                <avrf:trace>ntdll!KiUserExceptionDispatcher+2e ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::pass::low_precision::WeightableLayerTransformation::isQuantizedStatic+56a9f ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!std::enable_shared_from_this&lt;ov::Any::Base&gt;::weak_from_this+1ec ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::Input&lt;ov::Node&gt;::get_node+1ea6 ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::AttributeVisitor::get_name_with_context+c0 ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::op::v6::GatherElements::visit_attributes+83 ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::pass::SequenceFusion::SequenceFusion+6245 ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::pass::SequenceFusion::SequenceFusion+6647 ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::pass::SharedOpOptimization::run_on_model+d09 ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::pass::SharedOpOptimization::run_on_model+20 ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::pass::Manager::run_pass+2e8 ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::pass::Manager::run_passes+259 ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::preprocess::InputTensorInfo::set_spatial_static_shape+86b ( @ 0)</avrf:trace>
					                <avrf:trace>openvino!ov::preprocess::PrePostProcessor::build+531 ( @ 0)</avrf:trace>
					                <avrf:trace>etests!eTests::openvino::inference_graph_wrapper&lt;ovTestFixture&gt;::inference_graph_wrapper&lt;ovTestFixture&gt;+3b0 (D:\qb\workspace\33077\source\npu-driver\tests\etests\include\openvino\ov_inference_graph_wrapper.h @ 132)</avrf:trace>
					                <avrf:trace>etests!eTests::common::inference::inference&lt;ovTestFixture&gt;::inference&lt;ovTestFixture&gt;+85 (D:\qb\workspace\33077\source\npu-driver\tests\etests\include\common\inference\inference.h @ 79)</avrf:trace>
					                <avrf:trace>etests!eTests::common::inference::compile_test&lt;ovTestFixture&gt;::Run+ce (D:\qb\workspace\33077\source\npu-driver\tests\etests\include\common\compile.h @ 184)</avrf:trace>
					                <avrf:trace>etests!eTests::Runner::Execute&lt;eTests::common::inference::compile_test&lt;ovTestFixture&gt; &gt;+e (D:\qb\workspace\33077\source\npu-driver\tests\etests\include\common\runner.h @ 42)</avrf:trace>
					                <avrf:trace>etests!std::_Func_impl_no_alloc&lt;`ov_multi_compile_run_Test::TestBody&apos;::`2&apos;::&lt;lambda_1&gt;,void&gt;::_Do_call+a9 (D:\qb\workspace\33077\source\third_party\build-tools\ewdk\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.41.34120\include\functional @ 874)</avrf:trace>
					                <avrf:trace>etests!std::_Packaged_state&lt;void __cdecl(void)&gt;::_Call_immediate+1f (D:\qb\workspace\33077\source\third_party\build-tools\ewdk\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.41.34120\include\future @ 584)</avrf:trace>
					                <avrf:trace>etests!std::thread::_Invoke&lt;std::tuple&lt;std::packaged_task&lt;void __cdecl(void)&gt; &gt;,0&gt;+2e (D:\qb\workspace\33077\source\third_party\build-tools\ewdk\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.41.34120\include\thread @ 60)</avrf:trace>
					                <avrf:trace>etests!thread_start&lt;unsigned int (__cdecl*)(void *),1&gt;+4f (minkernel\crts\ucrt\src\appcrt\startup\thread.cpp @ 97)</avrf:trace>
					                <avrf:trace>vfbasics!+7ffc4bed7943 ( @ 0)</avrf:trace>
					                <avrf:trace>KERNEL32!BaseThreadInitThunk+17 ( @ 0)</avrf:trace>
					                <avrf:trace>ntdll!RtlUserThreadStart+2c ( @ 0)</avrf:trace>
					            </avrf:stackTrace>
					        </avrf:logEntry>
					    </avrf:logSession>
					</avrf:logfile>

```


### Tickets:
 - *ticket-id*
